### PR TITLE
feat: generate environment variable export commands

### DIFF
--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -20,7 +20,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.21
       -
         name: test build binaries
         if: github.ref_name == 'master'

--- a/.idea/ssm-get-parameter.iml
+++ b/.idea/ssm-get-parameter.iml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="JAVA_MODULE" version="4">
+  <component name="Go" enabled="true" />
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$" />

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
-FROM 		golang:1.19
+FROM 		golang:1.21
 WORKDIR		/app
 ADD		. /app
 RUN		CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' .
 
 FROM 		scratch
+COPY --from=0       /etc/passwd /etc/group /etc/
+COPY --from=0       /root /root
+COPY --from=0       /etc/ssl/certs/ /etc/ssl/certs/
 COPY --from=0		/app/ssm-get-parameter /
+ENTRYPOINT ["/ssm-get-parameter"]

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ ssm-get-parameter bash -c 'echo $PASSWORD'
 ```
 will print out the value of `/dev/mysql/root/password`.
 
+Alternatively, you can use --export as follows:
+
+```bash
+$ export PASSWORD=ssm:///password
+$ eval $(ssm-get-parameter --export)
+$ echo $PASSWORD
+```
+
 ## Dockerfile usage
 To idiomatic way to use the utility is as follows:
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/binxio/ssm-get-parameter
 
-go 1.19
+go 1.21
 
-require github.com/aws/aws-sdk-go v1.44.60
+require github.com/aws/aws-sdk-go v1.48.3
 
 require (
 	github.com/go-ini/ini v1.66.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/aws/aws-sdk-go v1.44.60 h1:KTTogelVR+4dWiIPl7eyxoxaJkziChON6/Y/hVfTipk=
 github.com/aws/aws-sdk-go v1.44.60/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
+github.com/aws/aws-sdk-go v1.48.3 h1:btYjT+opVFxUbRz+qSCjJe07cdX82BHmMX/FXYmoL7g=
+github.com/aws/aws-sdk-go v1.48.3/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-ini/ini v1.66.6/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=


### PR DESCRIPTION
allows to source the SSM parameter reference values into a script.

```bash
$ PASSWORD=ssm:///password
$ ssm-get-parameter --export
PASSWORD=P@ssw0rd
```

This allows for the import of the values in a script:

```bash
$ eval $(ssm-get-parameter --export)
$ echo $PASSWORD
```